### PR TITLE
Auto-size furniture labels to fit within item bounds

### DIFF
--- a/src/components/FurnitureItem.tsx
+++ b/src/components/FurnitureItem.tsx
@@ -113,11 +113,13 @@ export function FurnitureItem({ item, isSelected, snapPos, stageScale }: Props) 
   const isEllipse = item.shape === 'ellipse';
   const labelPadX = 8;
   const labelPadY = 4;
-  const availW = (isEllipse ? item.widthPx * 0.7 : item.widthPx) - labelPadX;
-  const availH = (isEllipse ? item.heightPx * 0.7 : item.heightPx) - labelPadY;
+  const availW = Math.max(1, (isEllipse ? item.widthPx * 0.7 : item.widthPx) - labelPadX);
+  const availH = Math.max(1, (isEllipse ? item.heightPx * 0.7 : item.heightPx) - labelPadY);
   const baseFontSize = calculateLabelFontSize(item.name, availW, availH);
   const labelFontSize = baseFontSize > 0 ? Math.max(baseFontSize, 10 / stageScale) : 0;
   const showLabel = labelFontSize > 0 || isSelected;
+  const labelBoxX = isEllipse ? item.widthPx * 0.15 : labelPadX / 2;
+  const labelBoxY = isEllipse ? item.heightPx * 0.15 : labelPadY / 2;
 
   // Clamp scale-compensated transformer values to prevent them from growing
   // absurdly large at low zoom or vanishing at high zoom.
@@ -145,14 +147,16 @@ export function FurnitureItem({ item, isSelected, snapPos, stageScale }: Props) 
         {showLabel && (
           <Text
             text={item.name}
-            x={isEllipse ? item.widthPx * 0.15 : 4}
-            y={item.heightPx / 2 - (labelFontSize > 0 ? labelFontSize : 10 / stageScale) / 2}
+            x={labelBoxX}
+            y={labelBoxY}
             width={availW}
+            height={availH}
             fontSize={labelFontSize > 0 ? labelFontSize : 10 / stageScale}
             fill={item.color}
             fontFamily="'DM Sans', sans-serif"
             fontStyle="600"
             align="center"
+            verticalAlign="middle"
             listening={false}
             wrap="word"
             ellipsis

--- a/src/utils/geometry.test.ts
+++ b/src/utils/geometry.test.ts
@@ -208,6 +208,17 @@ describe('calculateLabelFontSize', () => {
     expect(size).toBeLessThanOrEqual(18);
   });
 
+  it('treats word-wrapped overflow as not fitting within max lines', () => {
+    // At this width and size, naive char counting would say 2 lines, but word-wrap
+    // needs 3 lines: "alpha" / "beta" / "gamma".
+    const size = calculateLabelFontSize('alpha beta gamma', 54, 30, {
+      minSize: 10,
+      maxSize: 10,
+      maxLines: 2,
+    });
+    expect(size).toBe(0);
+  });
+
   it('returns 0 for tiny item where text cannot fit', () => {
     expect(calculateLabelFontSize('Bookshelf', 10, 10)).toBe(0);
   });

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -1,5 +1,57 @@
 import type { DetectedDimension, Point } from '../types';
 
+const LABEL_CHAR_WIDTH_RATIO = 0.6; // average character width / fontSize for DM Sans
+const LABEL_LINE_HEIGHT_RATIO = 1.3;
+
+function estimateWrappedLines(text: string, charsPerLine: number): number {
+  if (!text.trim()) return 1;
+
+  const paragraphs = text.split(/\n/);
+  let totalLines = 0;
+
+  for (const paragraph of paragraphs) {
+    if (!paragraph.trim()) {
+      totalLines += 1;
+      continue;
+    }
+
+    const words = paragraph.trim().split(/\s+/);
+    let lines = 1;
+    let currentLineLength = 0;
+
+    for (const word of words) {
+      const wordLength = word.length;
+
+      // Konva word wrapping will still break very long words when needed.
+      if (wordLength > charsPerLine) {
+        if (currentLineLength > 0) {
+          lines += 1;
+          currentLineLength = 0;
+        }
+        const fullWordLines = Math.floor((wordLength - 1) / charsPerLine);
+        lines += fullWordLines;
+        currentLineLength = wordLength % charsPerLine;
+        continue;
+      }
+
+      const nextLength = currentLineLength === 0
+        ? wordLength
+        : currentLineLength + 1 + wordLength;
+
+      if (nextLength <= charsPerLine) {
+        currentLineLength = nextLength;
+      } else {
+        lines += 1;
+        currentLineLength = wordLength;
+      }
+    }
+
+    totalLines += lines;
+  }
+
+  return totalLines;
+}
+
 /**
  * Parse dimension strings like 14'3" x 12', 21' x 20'6", 16'10", etc.
  * Returns { feet, inches, totalFeet } for each match.
@@ -134,18 +186,16 @@ export function calculateLabelFontSize(
   const minSize = options?.minSize ?? 7;
   const maxSize = options?.maxSize ?? 18;
   const maxLines = options?.maxLines ?? 3;
-  const charWidthRatio = 0.6; // average character width / fontSize for DM Sans
-  const lineHeightRatio = 1.3;
 
   if (availWidth <= 0 || availHeight <= 0 || text.length === 0) return 0;
 
   for (let size = maxSize; size >= minSize; size--) {
-    const charWidth = size * charWidthRatio;
+    const charWidth = size * LABEL_CHAR_WIDTH_RATIO;
     const charsPerLine = Math.floor(availWidth / charWidth);
     if (charsPerLine < 1) continue;
-    const linesNeeded = Math.ceil(text.length / charsPerLine);
+    const linesNeeded = estimateWrappedLines(text, charsPerLine);
     const lines = Math.min(linesNeeded, maxLines);
-    const textHeight = lines * size * lineHeightRatio;
+    const textHeight = lines * size * LABEL_LINE_HEIGHT_RATIO;
     // Check if text fits: all chars visible within maxLines, and height fits
     if (linesNeeded <= maxLines && textHeight <= availHeight) return size;
   }


### PR DESCRIPTION
Replace the fixed font-size formula (10-14px based only on width) with a dynamic `calculateLabelFontSize()` utility that considers both width and height, and enables word wrapping for long names.

## Changes

- **geometry.ts**: Added `calculateLabelFontSize(text, availWidth, availHeight, options?)` — steps down from 18px to 7px, estimating character layout with up to 3 lines of word wrap. Returns 0 when text can't fit (signal to hide).
- **FurnitureItem.tsx**: Replaced the old `Math.max(10/scale, Math.min(14, w*0.12))` formula with the new utility. Switched Konva `<Text>` from `wrap="none"` + ellipsis to `wrap="word"`. Labels hidden on tiny items but shown when selected. Ellipse shapes use 70% of bounds.
- **geometry.test.ts**: Added 9 tests covering wide/narrow/tiny items, long names, empty text, custom min/max options, and height constraints.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| 3-Seat Sofa (84"×36") | "3-Seat So..." (truncated at 14px) | "3-Seat Sofa" (full, ~18px) |
| Bookshelf on narrow shelf | "B..." | Smaller font, full name visible |
| Console Table (48"×16") | Fixed 14px, clipped vertically | Font sized to fit height |
| "Sectional Sofa with Chaise" | Heavily truncated | Word-wrapped across 2-3 lines |
| Toilet (18"×28") | Tiny truncated text | Label hidden, shown on select |

## Notes

- Pure function with no Konva dependency — uses character-width heuristic (0.6 × fontSize) instead of canvas measurement
- StageScale compensation preserved for zoom readability
- All 87 tests pass

Closes #11
