### PR TITLE
Improve placement flow UX and numeric input focus behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ A browser-based floor plan studio for arranging furniture to scale. Drop in a fl
 - **Floor plan import** — Load floor plan images via file picker or drag-and-drop; images stored in Supabase Storage
 - **Scale calibration** — Set two reference points and a known distance to establish real-world scale; OCR auto-detects printed dimensions via Tesseract.js
 - **Furniture catalog** — Pre-built library of common furniture (seating, tables, beds, storage, appliances, bathroom fixtures) with accurate real-world dimensions
+- **Placement mode workflow** — Pick an item, click to place repeatedly, switch presets while staying in placement mode, and use Done or Esc to exit
 - **Drag, rotate, snap** — Place and arrange items on the canvas with 15° rotation snapping, grid snapping, and locking
+- **Faster numeric editing** — Calibration and dimension fields select all on focus so typing immediately replaces the current value
 - **Custom shapes** — Draw arbitrary polygon regions directly on the plan
 - **Measurement tool** — Measure distances between any two points in calibrated feet/inches
 - **Share projects** — Generate read-only share links for collaborators and clients

--- a/src/App.css
+++ b/src/App.css
@@ -773,6 +773,11 @@ html, body, #root {
   border: 1.5px solid var(--mustard);
   border-radius: var(--radius-card);
   box-shadow: 0 0 0 3px rgba(233, 196, 106, 0.08);
+  animation: placePulse 1.6s ease-in-out infinite;
+}
+
+.palette-place-mode {
+  background: linear-gradient(180deg, rgba(233, 196, 106, 0.05) 0%, rgba(233, 196, 106, 0) 45%);
 }
 
 .placing-indicator-text { font-size: 13px; color: var(--text); margin-bottom: 8px; font-weight: 500; }
@@ -851,6 +856,11 @@ html, body, #root {
   box-shadow: 0 0 0 3px rgba(233, 196, 106, 0.15);
 }
 
+.palette-search:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
 .category-tabs { display: flex; gap: 4px; flex-wrap: wrap; }
 
 .cat-tab {
@@ -878,6 +888,12 @@ html, body, #root {
   color: var(--plaster);
   border-color: var(--forest);
   box-shadow: 0 2px 6px rgba(38, 70, 83, 0.2), 0 0 0 2px rgba(38, 70, 83, 0.08);
+}
+
+.cat-tab:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .preset-list {
@@ -1124,6 +1140,12 @@ html, body, #root {
 @keyframes fadeIn {
   from { opacity: 0; }
   to { opacity: 1; }
+}
+
+@keyframes placePulse {
+  0% { box-shadow: 0 0 0 2px rgba(233, 196, 106, 0.1); }
+  50% { box-shadow: 0 0 0 6px rgba(233, 196, 106, 0.2); }
+  100% { box-shadow: 0 0 0 2px rgba(233, 196, 106, 0.1); }
 }
 
 @keyframes breathe {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,6 +233,9 @@ function AppInner() {
       if (meta && e.key === 'z' && e.shiftKey) { e.preventDefault(); redo(); return; }
       if (meta && e.key === 'y') { e.preventDefault(); redo(); return; }
 
+      // Escape always exits to select mode
+      if (e.key === 'Escape') { dispatch({ type: 'SET_TOOL_MODE', payload: 'select' }); return; }
+
       // Don't intercept if typing in input
       if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'SELECT') return;
 
@@ -250,7 +253,7 @@ function AppInner() {
       }
 
       // Tool shortcuts
-      if (e.key === 'v' || e.key === 'Escape') { dispatch({ type: 'SET_TOOL_MODE', payload: 'select' }); return; }
+      if (e.key === 'v') { dispatch({ type: 'SET_TOOL_MODE', payload: 'select' }); return; }
       if (e.key === 'm') { dispatch({ type: 'SET_TOOL_MODE', payload: 'measure' }); return; }
       if (e.key === 'p') { dispatch({ type: 'SET_TOOL_MODE', payload: 'draw-polygon' }); return; }
       if (e.key === 'g') { dispatch({ type: 'TOGGLE_GRID' }); return; }

--- a/src/components/CalibrationPanel.test.tsx
+++ b/src/components/CalibrationPanel.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CalibrationPanel } from './CalibrationPanel';
+import { useAppState } from '../hooks/useAppState';
+
+vi.mock('../hooks/useAppState', () => ({
+  useAppState: vi.fn(),
+}));
+
+vi.mock('../hooks/useOCR', () => ({
+  useOCR: () => ({ runOCR: vi.fn() }),
+}));
+
+const mockedUseAppState = vi.mocked(useAppState);
+
+describe('CalibrationPanel', () => {
+  const dispatch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedUseAppState.mockReturnValue({
+      state: {
+        floorPlans: [],
+        activeFloorPlanId: null,
+        furniture: [],
+        selectedFurnitureId: null,
+        toolMode: 'calibrate',
+        calibration: {
+          points: [{ x: 0, y: 0 }, { x: 120, y: 0 }],
+          isActive: true,
+          detectedDimensions: [],
+          ocrProgress: 0,
+          ocrRunning: false,
+        },
+        measure: { points: [], distanceFt: null },
+        drawPolygon: { vertices: [], isDrawing: false },
+        exportSelection: { start: null, rect: null },
+        showGrid: true,
+        gridSizeIn: 12,
+        snapToGrid: false,
+        placingPreset: null,
+        stagePos: { x: 0, y: 0 },
+        stageScale: 1,
+      },
+      dispatch,
+      undo: vi.fn(),
+      redo: vi.fn(),
+      canUndo: false,
+      canRedo: false,
+    });
+  });
+
+  it('selects calibration inputs on focus', () => {
+    render(<CalibrationPanel />);
+
+    const [feetInput, inchesInput] = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+    const feetSelectSpy = vi.spyOn(feetInput, 'select');
+    const inchesSelectSpy = vi.spyOn(inchesInput, 'select');
+
+    fireEvent.focus(feetInput);
+    fireEvent.focus(inchesInput);
+
+    expect(feetSelectSpy).toHaveBeenCalled();
+    expect(inchesSelectSpy).toHaveBeenCalled();
+  });
+
+  it('preserves entered value when focus and blur happen without edits', () => {
+    render(<CalibrationPanel />);
+
+    const [feetInput] = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+
+    fireEvent.change(feetInput, { target: { value: '10' } });
+    fireEvent.focus(feetInput);
+    fireEvent.blur(feetInput);
+
+    expect(feetInput).toHaveValue(10);
+  });
+});

--- a/src/components/CalibrationPanel.tsx
+++ b/src/components/CalibrationPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import { useAppState } from '../hooks/useAppState';
 import { useOCR } from '../hooks/useOCR';
 import { computePixelsPerFoot, formatFeetInches, pixelDistance } from '../utils/geometry';
+import { selectAllOnFocus } from '../utils/inputFocus';
 
 export function CalibrationPanel() {
   const { state, dispatch } = useAppState();
@@ -144,6 +145,7 @@ export function CalibrationPanel() {
                       type="number"
                       value={manualFeet}
                       onChange={e => setManualFeet(e.target.value)}
+                      onFocus={selectAllOnFocus}
                       placeholder="0"
                       min="0"
                       step="1"
@@ -155,6 +157,7 @@ export function CalibrationPanel() {
                       type="number"
                       value={manualInches}
                       onChange={e => setManualInches(e.target.value)}
+                      onFocus={selectAllOnFocus}
                       placeholder="0"
                       min="0"
                       max="11"

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -16,8 +16,10 @@ export const Canvas = forwardRef<CanvasHandle>(function Canvas(_props, ref) {
   const { state, dispatch } = useAppState();
   const stageRef = useRef<Konva.Stage>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const placementFeedbackTimerRef = useRef<number | null>(null);
   const [dims, setDims] = useState({ width: 800, height: 600 });
   const [floorImage, setFloorImage] = useState<HTMLImageElement | null>(null);
+  const [justPlacedId, setJustPlacedId] = useState<string | null>(null);
 
   useImperativeHandle(ref, () => ({
     get stage() { return stageRef.current; },
@@ -49,6 +51,14 @@ export const Canvas = forwardRef<CanvasHandle>(function Canvas(_props, ref) {
     img.src = activeFloorPlan.imageUrl;
     img.onload = () => setFloorImage(img);
   }, [activeFloorPlan?.imageUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (placementFeedbackTimerRef.current !== null) {
+        window.clearTimeout(placementFeedbackTimerRef.current);
+      }
+    };
+  }, []);
 
   // Fit image when first loaded
   useEffect(() => {
@@ -154,6 +164,14 @@ export const Canvas = forwardRef<CanvasHandle>(function Canvas(_props, ref) {
           locked: false,
         };
         dispatch({ type: 'ADD_FURNITURE', payload: newItem });
+        setJustPlacedId(newItem.id);
+        if (placementFeedbackTimerRef.current !== null) {
+          window.clearTimeout(placementFeedbackTimerRef.current);
+        }
+        placementFeedbackTimerRef.current = window.setTimeout(() => {
+          setJustPlacedId(null);
+          placementFeedbackTimerRef.current = null;
+        }, 320);
         // Keep placing mode so user can place more
         return;
       }
@@ -410,6 +428,7 @@ export const Canvas = forwardRef<CanvasHandle>(function Canvas(_props, ref) {
               key={item.id}
               item={item}
               isSelected={state.selectedFurnitureId === item.id}
+              isJustPlaced={justPlacedId === item.id}
               snapPos={snapPos}
               stageScale={state.stageScale}
             />

--- a/src/components/FurnitureItem.tsx
+++ b/src/components/FurnitureItem.tsx
@@ -8,11 +8,12 @@ import { snapAngle, calculateLabelFontSize } from '../utils/geometry';
 interface Props {
   item: PlacedFurniture;
   isSelected: boolean;
+  isJustPlaced: boolean;
   snapPos: (x: number, y: number) => { x: number; y: number };
   stageScale: number;
 }
 
-export function FurnitureItem({ item, isSelected, snapPos, stageScale }: Props) {
+export function FurnitureItem({ item, isSelected, isJustPlaced, snapPos, stageScale }: Props) {
   const { state, dispatch } = useAppState();
   const groupRef = useRef<Konva.Group>(null);
   const trRef = useRef<Konva.Transformer>(null);
@@ -23,6 +24,31 @@ export function FurnitureItem({ item, isSelected, snapPos, stageScale }: Props) 
       trRef.current.getLayer()?.batchDraw();
     }
   }, [isSelected, item.widthPx, item.heightPx, item.rotation]);
+
+  useEffect(() => {
+    if (!isJustPlaced || !groupRef.current) return;
+
+    const node = groupRef.current;
+    node.scale({ x: 0.92, y: 0.92 });
+    node.opacity(0.65);
+
+    const tween = new Konva.Tween({
+      node,
+      duration: 0.22,
+      easing: Konva.Easings.EaseOut,
+      scaleX: 1,
+      scaleY: 1,
+      opacity: 1,
+    });
+
+    tween.play();
+
+    return () => {
+      tween.destroy();
+      node.scale({ x: 1, y: 1 });
+      node.opacity(1);
+    };
+  }, [isJustPlaced]);
 
   const handleDragEnd = useCallback(
     (e: Konva.KonvaEventObject<DragEvent>) => {

--- a/src/components/FurniturePalette.test.tsx
+++ b/src/components/FurniturePalette.test.tsx
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { FurniturePalette } from './FurniturePalette';
+import { useAppState } from '../hooks/useAppState';
+import { furniturePresets } from '../data/furniturePresets';
+import type { AppState } from '../types';
+
+vi.mock('../hooks/useAppState', () => ({
+  useAppState: vi.fn(),
+}));
+
+const mockedUseAppState = vi.mocked(useAppState);
+
+function createBaseState(overrides: Partial<AppState> = {}): AppState {
+  return {
+    floorPlans: [{
+      id: 'fp-1',
+      name: 'Test Plan',
+      imageUrl: 'test.png',
+      pixelsPerFoot: 24,
+      calibrationPoints: null,
+      calibrationDistanceFt: null,
+    }],
+    activeFloorPlanId: 'fp-1',
+    furniture: [],
+    selectedFurnitureId: null,
+    toolMode: 'select',
+    calibration: { points: [], isActive: false, detectedDimensions: [], ocrProgress: 0, ocrRunning: false },
+    measure: { points: [], distanceFt: null },
+    drawPolygon: { vertices: [], isDrawing: false },
+    exportSelection: { start: null, rect: null },
+    showGrid: true,
+    gridSizeIn: 12,
+    snapToGrid: false,
+    placingPreset: null,
+    stagePos: { x: 0, y: 0 },
+    stageScale: 1,
+    ...overrides,
+  };
+}
+
+describe('FurniturePalette', () => {
+  const dispatch = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows Done in placement mode and allows preset switching', () => {
+    mockedUseAppState.mockReturnValue({
+      state: createBaseState({ toolMode: 'place', placingPreset: furniturePresets[0] }),
+      dispatch,
+      undo: vi.fn(),
+      redo: vi.fn(),
+      canUndo: false,
+      canRedo: false,
+    });
+
+    render(<FurniturePalette />);
+
+    expect(screen.getByRole('button', { name: 'Done' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Loveseat/i }));
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'SET_PLACING_PRESET',
+      payload: expect.objectContaining({ id: 'sofa-2seat', name: 'Loveseat' }),
+    });
+  });
+
+  it('selects all custom dimensions on focus', () => {
+    mockedUseAppState.mockReturnValue({
+      state: createBaseState(),
+      dispatch,
+      undo: vi.fn(),
+      redo: vi.fn(),
+      canUndo: false,
+      canRedo: false,
+    });
+
+    render(<FurniturePalette />);
+    fireEvent.click(screen.getByRole('button', { name: /3-Seat Sofa/i }));
+
+    const [widthInput] = screen.getAllByRole('spinbutton') as HTMLInputElement[];
+    const selectSpy = vi.spyOn(widthInput, 'select');
+
+    fireEvent.focus(widthInput);
+
+    expect(selectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/components/FurniturePalette.tsx
+++ b/src/components/FurniturePalette.tsx
@@ -3,6 +3,7 @@ import { useAppState } from '../hooks/useAppState';
 import { furniturePresets, categories } from '../data/furniturePresets';
 import type { FurniturePreset } from '../types';
 import { pixelsToInches, formatFeetInches } from '../utils/geometry';
+import { selectAllOnFocus } from '../utils/inputFocus';
 
 export function FurniturePalette() {
   const { state, dispatch } = useAppState();
@@ -27,10 +28,15 @@ export function FurniturePalette() {
 
   const handleSelectPreset = useCallback((preset: FurniturePreset) => {
     if (!ppf) return;
+    if (state.toolMode === 'place') {
+      dispatch({ type: 'SET_PLACING_PRESET', payload: preset });
+      setEditingPreset(null);
+      return;
+    }
     setEditingPreset(preset);
     setCustomW(String(preset.widthIn));
     setCustomD(String(preset.depthIn));
-  }, [ppf]);
+  }, [ppf, state.toolMode, dispatch]);
 
   const handlePlace = useCallback(() => {
     if (!editingPreset) return;
@@ -51,7 +57,7 @@ export function FurniturePalette() {
   const selectedItem = state.furniture.find(f => f.id === state.selectedFurnitureId);
 
   return (
-    <div className="palette">
+    <div className={`palette ${state.toolMode === 'place' ? 'palette-place-mode' : ''}`}>
       <div className="palette-header">
         <h2>Furniture</h2>
       </div>
@@ -67,13 +73,13 @@ export function FurniturePalette() {
       {state.toolMode === 'place' && state.placingPreset && (
         <div className="placing-indicator">
           <div className="placing-indicator-text">
-            Click on the floor plan to place:<br />
+            Placement mode: click the floor plan to place<br />
             <strong>{state.placingPreset.name}</strong>
             <span className="placing-dims">
               {state.placingPreset.widthIn}" × {state.placingPreset.depthIn}"
             </span>
           </div>
-          <button className="btn-sm btn-cancel" onClick={handleCancelPlace}>Cancel</button>
+          <button className="btn-sm btn-cancel" onClick={handleCancelPlace}>Done</button>
         </div>
       )}
 
@@ -83,11 +89,11 @@ export function FurniturePalette() {
           <div className="preset-editor-name">{editingPreset.name}</div>
           <div className="dim-inputs">
             <label>
-              W<input type="number" value={customW} onChange={e => setCustomW(e.target.value)} min="1" step="1" />"
+              W<input type="number" value={customW} onChange={e => setCustomW(e.target.value)} onFocus={selectAllOnFocus} min="1" step="1" />"
             </label>
             <span className="dim-x">×</span>
             <label>
-              D<input type="number" value={customD} onChange={e => setCustomD(e.target.value)} min="1" step="1" />"
+              D<input type="number" value={customD} onChange={e => setCustomD(e.target.value)} onFocus={selectAllOnFocus} min="1" step="1" />"
             </label>
           </div>
           <div className="preset-editor-actions">
@@ -104,6 +110,7 @@ export function FurniturePalette() {
         placeholder="Search furniture..."
         value={search}
         onChange={e => setSearch(e.target.value)}
+        disabled={state.toolMode === 'place'}
       />
 
       {/* Category tabs */}
@@ -111,6 +118,7 @@ export function FurniturePalette() {
         <button
           className={`cat-tab ${!activeCategory ? 'active' : ''}`}
           onClick={() => setActiveCategory(null)}
+          disabled={state.toolMode === 'place'}
         >
           All
         </button>
@@ -119,6 +127,7 @@ export function FurniturePalette() {
             key={cat}
             className={`cat-tab ${activeCategory === cat ? 'active' : ''}`}
             onClick={() => setActiveCategory(cat)}
+            disabled={state.toolMode === 'place'}
           >
             {cat}
           </button>
@@ -130,7 +139,7 @@ export function FurniturePalette() {
         {filtered.map(preset => (
           <button
             key={preset.id}
-            className={`preset-item ${editingPreset?.id === preset.id ? 'active' : ''}`}
+            className={`preset-item ${editingPreset?.id === preset.id || state.placingPreset?.id === preset.id ? 'active' : ''}`}
             onClick={() => handleSelectPreset(preset)}
             disabled={!ppf}
             title={`${preset.widthIn}" × ${preset.depthIn}"`}

--- a/src/hooks/useAppState.test.tsx
+++ b/src/hooks/useAppState.test.tsx
@@ -478,4 +478,15 @@ describe('SET_PLACING_PRESET', () => {
     expect(result.current.state.placingPreset).toBeNull();
     expect(result.current.state.toolMode).toBe('select');
   });
+
+  it('keeps placing preset active when furniture is added', () => {
+    const { result } = setup();
+    const preset = { id: 'sofa-3seat', category: 'Seating', name: '3-Seat Sofa', widthIn: 84, depthIn: 36, shape: 'rect' as const, color: '#5B8C6B' };
+
+    act(() => result.current.dispatch({ type: 'SET_PLACING_PRESET', payload: preset }));
+    act(() => result.current.dispatch({ type: 'ADD_FURNITURE', payload: makeFurniture({ id: 'placed-1' }) }));
+
+    expect(result.current.state.toolMode).toBe('place');
+    expect(result.current.state.placingPreset).toEqual(preset);
+  });
 });

--- a/src/utils/inputFocus.ts
+++ b/src/utils/inputFocus.ts
@@ -1,0 +1,9 @@
+import type { FocusEvent } from 'react';
+
+export function selectAllOnFocus(event: FocusEvent<HTMLInputElement>) {
+  try {
+    event.target.select();
+  } catch {
+    // Some browsers do not support text selection APIs on number inputs.
+  }
+}


### PR DESCRIPTION
## Summary

Jointly addresses **#21** (placement flow UX) and **#24** (numeric input focus behavior).

### Placement flow (issue #21)
- Renamed placement exit button from "Cancel" to "Done" — matches user intent (completion, not rollback)
- Palette stays open during placement with preset switching enabled; search and category tabs are disabled to keep focus on placing
- Added subtle scale+opacity confirmation animation when a furniture item is placed
- Escape key now exits placement mode even when an input field is focused
- Added pulsing glow on the placement indicator for stronger visual affordance

### Numeric input focus (issue #24)
- All numeric inputs (calibration feet/inches, palette width/depth) now select-all on focus so typing immediately replaces the current value
- Added shared `selectAllOnFocus` utility in `src/utils/inputFocus.ts`
- Original value preserved on focus then blur without edits

### Tests
- Extended `useAppState` reducer tests: placement preset persists across sequential `ADD_FURNITURE` dispatches
- New `FurniturePalette.test.tsx`: Done button rendering, preset switching in placement mode, select-all on dimension focus
- New `CalibrationPanel.test.tsx`: select-all on calibration input focus, value preservation on blur

### Docs
- Updated README with placement workflow and numeric editing feature bullets

Closes #21, closes #24
